### PR TITLE
Fix stale/drifted schema docs and rewrite naming conventions

### DIFF
--- a/doc/metadata-block-field-naming.md
+++ b/doc/metadata-block-field-naming.md
@@ -1,30 +1,35 @@
-Some guidelines for naming blocks and fields in the metadata schema 
-documentation and how to implement the schema in the API implementation.
+Guidelines for naming blocks and fields in the metadata schema documentation,
+and how those names map to the actual RAiD API/data model implementation
+(the LinkML model in `au-research/raid-au`, `api-svc/datamodel/src/v2/`).
 
+**Note (2026-07-29):** this document previously described a flattened,
+block-name-prefixed field convention (e.g. `identifierSchemeUri`,
+`titleStartDate`). That convention was never actually implemented — neither
+in the real API nor in this repository's own schema documentation, both of
+which use the nested dot-path structure described below. This document has
+been rewritten to describe what is actually implemented.
 
 # Terminology
 
-* Case name terms come from: 
-https://web.archive.org/web/20230208161922/https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats
+* Case name terms come from:
+  https://web.archive.org/web/20230208161922/https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats
   * examples:
-    * "camel case" : "identifierBlock"  
-    * "pascal case" : "IdentifierBlock"  
-* "Schema documentation" refers to the Google drive
-  [RAiD Metadata Schema v0-5](https://docs.google.com/document/d/1qL1evcBDv4KsV18wqm99RPg3iUNvVndZ1zKJY2i649Y/edit#)
+    * "camel case": `identifier`
+    * "pascal case": `Identifier`
+* "Schema documentation" refers to the RST source in `rtd/docs/source/`
+  (rendered at https://metadata.raid.org), which is itself sourced from the
+  LinkML data model in `au-research/raid-au`.
 
+# Block names
 
-# Schema documentation 
-
-## Block names
-
-Block names aren't physically present in the metadata, but their naming is used
-to drive the API for things like field names - so we need to be careful and 
-consistent.
+Block names aren't physically present in the metadata as a key, but they
+name the LinkML class that defines a block's properties (e.g. the
+`identifier` root field's values are defined by the LinkML class `Id`; the
+`title` root field's values are defined by the class `Title`).
 
 ### Pluralisation
 
-Always use the singular.  Mostly just because english has weird and 
-inconsistent pluralisation rules.
+Always use the singular.
 
 #### Examples
 
@@ -33,213 +38,123 @@ inconsistent pluralisation rules.
 
 ### Capitalisation
 
-The schema documentation may use whatever case it wants, but it does not 
-drive the capitalisation of field identifiers or type names in the API 
-(defined below).
+Pascal case, matching the LinkML class name directly — **no suffix** (e.g.
+`Title`, `Access`, `Contributor`, `RelatedRaid`; not `TitleBlock`,
+`AccessBlock`, etc.). Initialisms and acronyms are treated as proper words.
 
-This allows the schema documentation to represent names in reader-friendly 
-capitalisation that makes things easier for humans to understand, for example:
-"identifierURL", or "RAiD". 
+Schema documentation prose may use whatever reader-friendly capitalisation
+makes sense (e.g. "identifierURL", "RAiD") — this never drives the actual
+class/type name in the data model or API.
 
-## Root fields
+# Root fields
 
-Talking here about fields at the root level of the meta schema, the fields that
-contain the blocks.
-
-### Naming standard
-
-Use the same name as the block name.
-
-
-## Block fields
-
-Talking here about fields inside a block.
+Fields at the root level of the metadata document that hold a block's
+values.
 
 ### Naming standard
 
-Prepend the block name to the field name.
-
-Yes, this means there's a lot of duplication of the block name withing the 
-field names.
-
-We don't know why we do this - we're just copying what DataCite and other 
-schema definitions do.  It has the advantage of not needing any kind of 
-exemptions or edge case rules (for example what do you do with `title.title`
-if you insist on de-duplicating the names).
-
-#### Examples
-
-* `Identifier` block field names
-  * `identifierSchemeURI`
-  * `identifierServicePoint`
-* `Date` block field names
-  * `dateStart`
-  * `dateEnd`
-
-### Capitalisation
-
-The schema documentation may use whatever case it wants, but it does not
-drive the capitalisation of field identifiers or type names in the API
-(defined below).
-
----
-
-# API implementation 
-
-## Block Type names
-
-The "Type name" is a technical thing, in OpenAPI we map a metadata schema block 
-as a [component schema](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#components-object).
-
-In Java or TypeScript, the block maps to a class or interface.
-
-### Naming standard
-
-Append the word `Block` to the block name used in the schema documentation.
-
-e.g. `Identifier` is mapped to type name `IdentifierBlock`, `Title` -> 
-`TitleBlock`, etc.
-  
-### Capitalisation
-
-Use pascal case for the block type name.
-
-Initialisms and acronyms should be treated as proper words.
-
-### Examples
-
-* `IdentifierBlock`
-* `TitleBlock`
-* `AccessBlock`
-* `AlternateUrlBlock`
-* `RelatedRaidBlock`
-
-
-### Pluralisation 
-
-Stick to the singular, as used in the schema documentation.
-
-### Examples
-* use `TitleBlock`, not `TitlesBlock`
-
-
-## Root fields
-
-Talking here about fields at the root level of the meta schema, the fields that
-contain the blocks.
-
-### Naming standard
-
-Use the block name for the field that contains the values of that block.
-
-####
-* use `identifier` 
-  * not `Identifier` or `IdentifierBlock`
-* use `title` 
-  * not `tiles` or `Titles` or `titleBlocks`
-
-### Pluralisation
-
-Always use the singular.
-
-####
-
-* use `title`, not `titles`
-* use `relatedRaid`, not `relatedRAiDs`
-
-### Capitalisation
-
-Use camel case.
+Use the same name as the block, camel case, singular.
 
 #### Examples
 
 * `identifier`
-* `relatedRaid`
+* `title`
+* `relatedRaid` (not `relatedRAiDs`)
 * `alternateUrl`
 
+# Fields within a block (and sub-blocks)
 
-## Block fields
-
-Talking here about fields within a block.
+Fields nested inside a block, or inside a sub-block nested within a block.
 
 ### Naming standard
 
-Field names should be derived directly from the name in the schema 
-documentation, including maintaining the "duplication" of the block name 
-within the field name.
-
-###$ Examples
-
-* `IdentifierBlock`, stored in field named `identifier`
-  * `identifier`
-  * `identifierSchemeUri`
-  * `identifierRegistrationAgency`
-  * `identifierOwner`
-  * `identifierServicePoint`
-
-### Capitalisation
-
-Use camel case.
+Plain camel case, with **no** repetition of the parent block's name — the
+nesting itself (dot-path) is what scopes the field, not a name prefix.
 
 #### Examples
 
-* `IdentifierBlock`, stored in field named `identifier`
-  * `identifier`
-  * `identifierSchemeUri`
-* `RelatedRaidBlock`, stored in field `relatedRaid`
-  * `relatedRaid`
-  * `relatedRaidType`
-  * `relatedRaidTypeSchemeUri`
+* `identifier` block (LinkML class `Id`):
+  * `identifier.schemaUri`
+  * `identifier.registrationAgency.id`
+  * `identifier.registrationAgency.schemaUri`
+  * `identifier.owner.id`
+  * `identifier.owner.schemaUri`
+  * `identifier.owner.servicePoint`
+* `title` block (LinkML class `Title`):
+  * `title.text`
+  * `title.startDate`
+  * `title.type.id`
+  * `title.type.schemaUri`
+* `relatedRaid` block (LinkML class `RelatedRaid`):
+  * `relatedRaid.id`
+  * `relatedRaid.type.id`
+  * `relatedRaid.type.schemaUri`
+
+This matches both the LinkML attribute names directly and the section
+numbering already used throughout `rtd/docs/source/` (e.g.
+`core/identifier.rst`'s `1.3.1 identifier.registrationAgency.id`).
 
 ---
 
-# Final example
+# Worked example
 
-```
+```json
 {
-  "metadataSchema": "RaidoMetadataSchemaV2",
   "identifier": {
-    "identifier": "https://raid.org/prefix/suffix",
-    "identifierSchemeUri": "https://raid.org",
-    "identifierRegistrationAgency": "https://ror.org/038sjwq14",
-    "identifierOwner": "https://ror.org/038sjwq14",
-    "identifierServicePoint": 20000000,
+    "id": "https://raid.org/prefix/suffix",
+    "schemaUri": "https://raid.org/",
+    "registrationAgency": {
+      "id": "https://ror.org/038sjwq14",
+      "schemaUri": "https://ror.org"
+    },
+    "owner": {
+      "id": "https://ror.org/038sjwq14",
+      "schemaUri": "https://ror.org/",
+      "servicePoint": 20000000
+    },
+    "license": "Creative Commons CC-0",
+    "version": 1
   },
- "date": {
-    "dateStart": "2023-03-08T00:00:00.000Z"
+  "date": {
+    "startDate": "2023-03-08"
   },
   "title": [
     {
-      "title": "sto mint 1",
-      "titleType": "sto mint 1",
-      "titleTypeSchemeUri": "Primary Title",
-      "titleStartDate": "2023-03-08T00:00:00.000Z"
+      "text": "sto mint 1",
+      "type": {
+        "id": "https://vocabulary.raid.org/title.type.id/380",
+        "schemaUri": "https://vocabulary.raid.org/title.type.schema/376"
+      },
+      "startDate": "2023-03-08"
     }
   ],
   "contributor": [
     {
-      "contributor": "https://orcid.org/0009-0004-9651-5072",
-      "contributorIdentifierSchemeUri": "https://orcid.org/",
-      "contributorPosition": [
+      "id": "https://orcid.org/0009-0004-9651-5072",
+      "schemaUri": "https://orcid.org/",
+      "position": [
         {
-          "contributorPosition": "Leader",
-          "contributorPositionSchemaUri": "https://raid.org/",
-          "contributorPositionStartDate": "2023-03-08T00:00:00.000Z"
+          "id": "https://vocabulary.raid.org/contributor.position.schema/307",
+          "schemaUri": "https://vocabulary.raid.org/contributor.position.schema/305",
+          "startDate": "2023-03-08"
         }
       ],
-      "contributorRole": [
+      "role": [
         {
-          "contributorRole": "project-administration"
-          "contributorRoleSchemeUri": "https://credit.niso.org/",
+          "id": "https://credit.niso.org/contributor-roles/project-administration/",
+          "schemaUri": "https://credit.niso.org/"
         }
       ]
     }
-  ],  
+  ],
   "relatedRaid": [
     {
-      "relatedRaid": "https://raid.org/prefix/suffix"
-      "relatedRaidType": "https://github.com/au-research/raid-metadata/tree/main/scheme/related-raid/continues.json"
-      "relatedRaidTypeSchemeUri": "https://github.com/au-research/raid-metadata/tree/main/scheme/related-raid",
+      "id": "https://raid.org/prefix/suffix",
+      "type": {
+        "id": "https://vocabulary.raid.org/relatedRaid.type.schema/204",
+        "schemaUri": "https://vocabulary.raid.org/relatedRaid.type.schemaUri/285"
+      }
     }
   ]
+}
 ```

--- a/rtd/docs/source/core/contributors.rst
+++ b/rtd/docs/source/core/contributors.rst
@@ -41,14 +41,11 @@
 **Allowed values**: *closed controlled list defined at https://vocabulary.raid.org/contributor.schemaUri/215*
 
 * ``https://orcid.org/`` (ORCID)
-
-**Proposed values**: *not yet implemented*
-
 * ``https://isni.org/`` (ISNI)
 
-**Constraints**: a PID is required and (currently) only ORCID is allowed
+**Constraints**: a PID is required; ORCID and ISNI are currently allowed
 
-**Note**: The controlled list of allowed identifier schemas is defined at https://vocabulary.raid.org/contributor.schemaUri/215 and is shared across all Registration Agencies.
+**Note**: The controlled list of allowed identifier schemas is defined at https://vocabulary.raid.org/contributor.schemaUri/215 and is shared across all Registration Agencies. An ORCID Sandbox schema (``https://sandbox.orcid.org/``) is also present in the controlled list for testing purposes only and is not intended for production RAiD records. ISNI existence is verified against the ISNI registry; local checksum validation of the ISNI check digit ahead of that lookup is planned but not yet implemented.
 
 .. _5.3-contributor.position:
 

--- a/rtd/docs/source/core/core.rst
+++ b/rtd/docs/source/core/core.rst
@@ -25,5 +25,6 @@ Contents
    alternateUrls
    relatedRaids
    access
+   metadata
 
 

--- a/rtd/docs/source/core/identifier.rst
+++ b/rtd/docs/source/core/identifier.rst
@@ -177,9 +177,24 @@
 
 **Note**: A RAiD minted by a Registration Agency must have an SP associated with an Owner affiliated with that Agency; Registration Agencies must maintain and register lists of their Service Points with the RAiD Registration Authority. 
 
-.. _1.5-identifier.license:
+.. _1.5-identifier.raidAgencyUrl:
 
-1.5 identifier.license
+1.5 identifier.raidAgencyUrl
+-----------------------------
+
+**Definition**: the URL for the RAiD via the minting Registration Agency's own system
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Allowed values**: system-supplied URL
+
+**Note**: Set automatically by the RAiD Service software; not user-editable.
+
+.. _1.6-identifier.license:
+
+1.6 identifier.license
 ----------------------
 
 **Definition**: the licence, or licence waiver, under which the RAiD metadata record associated with this Identifier has been issued.
@@ -196,9 +211,9 @@
 
 **Note**: All RAiD metadata is available on a 'no rights reserved' basis unless prohibited by law. 
 
-.. _1.6-identifier.version:
+.. _1.7-identifier.version:
 
-1.6 identifier.version
+1.7 identifier.version
 ----------------------
 
 **Definition**: the version number of the RAiD

--- a/rtd/docs/source/core/metadata.rst
+++ b/rtd/docs/source/core/metadata.rst
@@ -1,0 +1,49 @@
+.. autosummary::
+   :toctree: generated
+
+.. _15-metadata:
+
+15 metadata
+===========
+
+**Definition**: a metadata schema block containing system-managed record-keeping properties for the RAiD
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Example JSON**
+
+.. _15.1-metadata.created:
+
+15.1 metadata.created
+----------------------
+
+**Definition**: the date and time the RAiD was created
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Allowed values**: system-supplied, read-only
+
+**Format**: epoch seconds
+
+**Note**: Set automatically by the RAiD Service software when a RAiD is created; not user-editable.
+
+.. _15.2-metadata.updated:
+
+15.2 metadata.updated
+----------------------
+
+**Definition**: the date and time the RAiD was last updated
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Allowed values**: system-supplied, read-only
+
+**Format**: epoch seconds
+
+**Note**: Set automatically by the RAiD Service software whenever a RAiD is updated; not user-editable.

--- a/rtd/docs/source/extended/spatialCoverages.rst
+++ b/rtd/docs/source/extended/spatialCoverages.rst
@@ -34,7 +34,6 @@
 * ``https://nominatim.openstreetmap.org/ui/details.html?osmtype=W&osmid=26707240&class=historic`` (Pompeii, Italy, OpenStreetMap)
 * ``https://www.geonames.org/264371/athens.html`` (Athens, Greece, from Geonames)
 * ``https://www.geonames.org/2161776/katoomba.html`` (Katoomba, NSW, Australia, from Geonames)
-* ``https://marineregions.org/gazetteer.php?p=details&id=62967`` (Abrolhos Australian Marine Park, Australia)
 
 .. _13.2-spatialCoverage.schemaUri:
 
@@ -49,14 +48,10 @@
 
 **Allowed values**: *open controlled list of URIs defined at https://vocabulary.raid.org/spatialCoverage.schemaUri/167*
 
-* ``https://nominatim.openstreetmap.org/`` (OpenStreetMap)
-
-**Proposed values**: *not yet implemented*
-
+* ``https://www.openstreetmap.org/`` (OpenStreetMap)
 * ``https://www.geonames.org/`` (Geonames)
-* ``https://marineregions.org/gazetteer.php`` (Marine Regions)
 
-**Note**: OpenStreetMap or (as appropriate) Marine Regions preferred, Geonames allowed; other geoname servers can be nominated by Registration Agencies.
+**Note**: OpenStreetMap preferred, Geonames allowed; other geoname servers can be nominated by Registration Agencies.
 
 .. _13.3-spatialCoverage.place:
 

--- a/rtd/docs/source/extended/subjects.rst
+++ b/rtd/docs/source/extended/subjects.rst
@@ -46,10 +46,7 @@
 **Allowed values**: *open controlled list of URIs defined at https://vocabulary.raid.org/subject.schemaUri/193*
 
 * https://vocabs.ardc.edu.au/viewById/316 (Australian and New Zealand Standard Research Classification 2020: Fields of Research)
-
-**Proposed values**: *not yet implemented*
-
-* https://id.loc.gov/authorities/subject.html (Library of Congress Subject Headings)
+* https://vocabs.ardc.edu.au/viewById/317 (Australian and New Zealand Standard Research Classification 2020: Socio-Economic Objectives)
 
 Other subject schemas can be nominated by Registration Agencies.
 

--- a/rtd/docs/source/index.rst
+++ b/rtd/docs/source/index.rst
@@ -96,6 +96,7 @@ Contents
       core/alternateUrls
       core/relatedRaids
       core/access
+      core/metadata
    extended/extended
       extended/subjects
       extended/traditionalKnowledgeLabels


### PR DESCRIPTION
## Summary

Audited `rtd/docs/source/` and `doc/metadata-block-field-naming.md` against the RAiD LinkML model, the actual running service (`au-research/raid-au`), and a production data export, since both had drifted from reality over time.

- `contributors.rst`: ISNI is live (was marked "proposed, not yet implemented"); noted ORCID Sandbox and the still-pending local checksum hardening (RAID-791)
- `spatialCoverages.rst`: Geonames is live; corrected the OpenStreetMap schemaUri to the value actually configured in the service; removed Marine Regions (descoped)
- `subjects.rst`: added ANZSRC Socio-Economic Objectives (real seed data since Dec 2025); removed Library of Congress (descoped)
- `identifier.rst`: documented `raidAgencyUrl`, confirmed mandatory/system-supplied (present in 100% of a 575-record production sample)
- `metadata.rst` (new page): documents the previously-undocumented `metadata` block — `created`/`updated` only; `raidModelVersion` intentionally left out since nothing implements it yet
- `metadata-block-field-naming.md`: rewritten to describe the nested dot-path field convention that's actually implemented (e.g. `identifier.schemaUri`), replacing a flattened-field-name convention (`identifierSchemeUri`) that was never real

Every change was verified against validator source, Spring config, DB migration history, relevant Jira tickets, and the ARDC RAiD AU Zenodo data archive (`10.5281/zenodo.21331421`) — not just the schema/vocab layer, which turned out to be an unreliable signal on its own in both directions.

## Test plan

- [ ] Confirm Sphinx build succeeds (`cd rtd/docs && make html`)
- [ ] Spot-check rendered `identifier`, `metadata`, `contributors`, `subjects`, `spatialCoverages` pages
- [ ] Confirm heading numbering (1.5–1.7 in `identifier.rst`; new `15` in `metadata.rst`) doesn't collide with anything else in the toctree

🤖 Generated with [Claude Code](https://claude.com/claude-code)