### PR TITLE
Fix stale/drifted schema docs and rewrite naming conventions

### DIFF
--- a/doc/metadata-block-field-naming.md
+++ b/doc/metadata-block-field-naming.md
@@ -1,30 +1,35 @@
-Some guidelines for naming blocks and fields in the metadata schema 
-documentation and how to implement the schema in the API implementation.
+Guidelines for naming blocks and fields in the metadata schema documentation,
+and how those names map to the actual RAiD API/data model implementation
+(the LinkML model in `au-research/raid-au`, `api-svc/datamodel/src/v2/`).
 
+**Note (2026-07-29):** this document previously described a flattened,
+block-name-prefixed field convention (e.g. `identifierSchemeUri`,
+`titleStartDate`). That convention was never actually implemented — neither
+in the real API nor in this repository's own schema documentation, both of
+which use the nested dot-path structure described below. This document has
+been rewritten to describe what is actually implemented.
 
 # Terminology
 
-* Case name terms come from: 
-https://web.archive.org/web/20230208161922/https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats
+* Case name terms come from:
+  https://web.archive.org/web/20230208161922/https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats
   * examples:
-    * "camel case" : "identifierBlock"  
-    * "pascal case" : "IdentifierBlock"  
-* "Schema documentation" refers to the Google drive
-  [RAiD Metadata Schema v0-5](https://docs.google.com/document/d/1qL1evcBDv4KsV18wqm99RPg3iUNvVndZ1zKJY2i649Y/edit#)
+    * "camel case": `identifier`
+    * "pascal case": `Identifier`
+* "Schema documentation" refers to the RST source in `rtd/docs/source/`
+  (rendered at https://metadata.raid.org), which is itself sourced from the
+  LinkML data model in `au-research/raid-au`.
 
+# Block names
 
-# Schema documentation 
-
-## Block names
-
-Block names aren't physically present in the metadata, but their naming is used
-to drive the API for things like field names - so we need to be careful and 
-consistent.
+Block names aren't physically present in the metadata as a key, but they
+name the LinkML class that defines a block's properties (e.g. the
+`identifier` root field's values are defined by the LinkML class `Id`; the
+`title` root field's values are defined by the class `Title`).
 
 ### Pluralisation
 
-Always use the singular.  Mostly just because english has weird and 
-inconsistent pluralisation rules.
+Always use the singular.
 
 #### Examples
 
@@ -33,213 +38,123 @@ inconsistent pluralisation rules.
 
 ### Capitalisation
 
-The schema documentation may use whatever case it wants, but it does not 
-drive the capitalisation of field identifiers or type names in the API 
-(defined below).
+Pascal case, matching the LinkML class name directly — **no suffix** (e.g.
+`Title`, `Access`, `Contributor`, `RelatedRaid`; not `TitleBlock`,
+`AccessBlock`, etc.). Initialisms and acronyms are treated as proper words.
 
-This allows the schema documentation to represent names in reader-friendly 
-capitalisation that makes things easier for humans to understand, for example:
-"identifierURL", or "RAiD". 
+Schema documentation prose may use whatever reader-friendly capitalisation
+makes sense (e.g. "identifierURL", "RAiD") — this never drives the actual
+class/type name in the data model or API.
 
-## Root fields
+# Root fields
 
-Talking here about fields at the root level of the meta schema, the fields that
-contain the blocks.
-
-### Naming standard
-
-Use the same name as the block name.
-
-
-## Block fields
-
-Talking here about fields inside a block.
+Fields at the root level of the metadata document that hold a block's
+values.
 
 ### Naming standard
 
-Prepend the block name to the field name.
-
-Yes, this means there's a lot of duplication of the block name withing the 
-field names.
-
-We don't know why we do this - we're just copying what DataCite and other 
-schema definitions do.  It has the advantage of not needing any kind of 
-exemptions or edge case rules (for example what do you do with `title.title`
-if you insist on de-duplicating the names).
-
-#### Examples
-
-* `Identifier` block field names
-  * `identifierSchemeURI`
-  * `identifierServicePoint`
-* `Date` block field names
-  * `dateStart`
-  * `dateEnd`
-
-### Capitalisation
-
-The schema documentation may use whatever case it wants, but it does not
-drive the capitalisation of field identifiers or type names in the API
-(defined below).
-
----
-
-# API implementation 
-
-## Block Type names
-
-The "Type name" is a technical thing, in OpenAPI we map a metadata schema block 
-as a [component schema](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#components-object).
-
-In Java or TypeScript, the block maps to a class or interface.
-
-### Naming standard
-
-Append the word `Block` to the block name used in the schema documentation.
-
-e.g. `Identifier` is mapped to type name `IdentifierBlock`, `Title` -> 
-`TitleBlock`, etc.
-  
-### Capitalisation
-
-Use pascal case for the block type name.
-
-Initialisms and acronyms should be treated as proper words.
-
-### Examples
-
-* `IdentifierBlock`
-* `TitleBlock`
-* `AccessBlock`
-* `AlternateUrlBlock`
-* `RelatedRaidBlock`
-
-
-### Pluralisation 
-
-Stick to the singular, as used in the schema documentation.
-
-### Examples
-* use `TitleBlock`, not `TitlesBlock`
-
-
-## Root fields
-
-Talking here about fields at the root level of the meta schema, the fields that
-contain the blocks.
-
-### Naming standard
-
-Use the block name for the field that contains the values of that block.
-
-####
-* use `identifier` 
-  * not `Identifier` or `IdentifierBlock`
-* use `title` 
-  * not `tiles` or `Titles` or `titleBlocks`
-
-### Pluralisation
-
-Always use the singular.
-
-####
-
-* use `title`, not `titles`
-* use `relatedRaid`, not `relatedRAiDs`
-
-### Capitalisation
-
-Use camel case.
+Use the same name as the block, camel case, singular.
 
 #### Examples
 
 * `identifier`
-* `relatedRaid`
+* `title`
+* `relatedRaid` (not `relatedRAiDs`)
 * `alternateUrl`
 
+# Fields within a block (and sub-blocks)
 
-## Block fields
-
-Talking here about fields within a block.
+Fields nested inside a block, or inside a sub-block nested within a block.
 
 ### Naming standard
 
-Field names should be derived directly from the name in the schema 
-documentation, including maintaining the "duplication" of the block name 
-within the field name.
-
-###$ Examples
-
-* `IdentifierBlock`, stored in field named `identifier`
-  * `identifier`
-  * `identifierSchemeUri`
-  * `identifierRegistrationAgency`
-  * `identifierOwner`
-  * `identifierServicePoint`
-
-### Capitalisation
-
-Use camel case.
+Plain camel case, with **no** repetition of the parent block's name — the
+nesting itself (dot-path) is what scopes the field, not a name prefix.
 
 #### Examples
 
-* `IdentifierBlock`, stored in field named `identifier`
-  * `identifier`
-  * `identifierSchemeUri`
-* `RelatedRaidBlock`, stored in field `relatedRaid`
-  * `relatedRaid`
-  * `relatedRaidType`
-  * `relatedRaidTypeSchemeUri`
+* `identifier` block (LinkML class `Id`):
+  * `identifier.schemaUri`
+  * `identifier.registrationAgency.id`
+  * `identifier.registrationAgency.schemaUri`
+  * `identifier.owner.id`
+  * `identifier.owner.schemaUri`
+  * `identifier.owner.servicePoint`
+* `title` block (LinkML class `Title`):
+  * `title.text`
+  * `title.startDate`
+  * `title.type.id`
+  * `title.type.schemaUri`
+* `relatedRaid` block (LinkML class `RelatedRaid`):
+  * `relatedRaid.id`
+  * `relatedRaid.type.id`
+  * `relatedRaid.type.schemaUri`
+
+This matches both the LinkML attribute names directly and the section
+numbering already used throughout `rtd/docs/source/` (e.g.
+`core/identifier.rst`'s `1.3.1 identifier.registrationAgency.id`).
 
 ---
 
-# Final example
+# Worked example
 
-```
+```json
 {
-  "metadataSchema": "RaidoMetadataSchemaV2",
   "identifier": {
-    "identifier": "https://raid.org/prefix/suffix",
-    "identifierSchemeUri": "https://raid.org",
-    "identifierRegistrationAgency": "https://ror.org/038sjwq14",
-    "identifierOwner": "https://ror.org/038sjwq14",
-    "identifierServicePoint": 20000000,
+    "id": "https://raid.org/prefix/suffix",
+    "schemaUri": "https://raid.org/",
+    "registrationAgency": {
+      "id": "https://ror.org/038sjwq14",
+      "schemaUri": "https://ror.org"
+    },
+    "owner": {
+      "id": "https://ror.org/038sjwq14",
+      "schemaUri": "https://ror.org/",
+      "servicePoint": 20000000
+    },
+    "license": "Creative Commons CC-0",
+    "version": 1
   },
- "date": {
-    "dateStart": "2023-03-08T00:00:00.000Z"
+  "date": {
+    "startDate": "2023-03-08"
   },
   "title": [
     {
-      "title": "sto mint 1",
-      "titleType": "sto mint 1",
-      "titleTypeSchemeUri": "Primary Title",
-      "titleStartDate": "2023-03-08T00:00:00.000Z"
+      "text": "sto mint 1",
+      "type": {
+        "id": "https://vocabulary.raid.org/title.type.id/380",
+        "schemaUri": "https://vocabulary.raid.org/title.type.schema/376"
+      },
+      "startDate": "2023-03-08"
     }
   ],
   "contributor": [
     {
-      "contributor": "https://orcid.org/0009-0004-9651-5072",
-      "contributorIdentifierSchemeUri": "https://orcid.org/",
-      "contributorPosition": [
+      "id": "https://orcid.org/0009-0004-9651-5072",
+      "schemaUri": "https://orcid.org/",
+      "position": [
         {
-          "contributorPosition": "Leader",
-          "contributorPositionSchemaUri": "https://raid.org/",
-          "contributorPositionStartDate": "2023-03-08T00:00:00.000Z"
+          "id": "https://vocabulary.raid.org/contributor.position.schema/307",
+          "schemaUri": "https://vocabulary.raid.org/contributor.position.schema/305",
+          "startDate": "2023-03-08"
         }
       ],
-      "contributorRole": [
+      "role": [
         {
-          "contributorRole": "project-administration"
-          "contributorRoleSchemeUri": "https://credit.niso.org/",
+          "id": "https://credit.niso.org/contributor-roles/project-administration/",
+          "schemaUri": "https://credit.niso.org/"
         }
       ]
     }
-  ],  
+  ],
   "relatedRaid": [
     {
-      "relatedRaid": "https://raid.org/prefix/suffix"
-      "relatedRaidType": "https://github.com/au-research/raid-metadata/tree/main/scheme/related-raid/continues.json"
-      "relatedRaidTypeSchemeUri": "https://github.com/au-research/raid-metadata/tree/main/scheme/related-raid",
+      "id": "https://raid.org/prefix/suffix",
+      "type": {
+        "id": "https://vocabulary.raid.org/relatedRaid.type.schema/204",
+        "schemaUri": "https://vocabulary.raid.org/relatedRaid.type.schemaUri/285"
+      }
     }
   ]
+}
 ```

--- a/rtd/docs/source/core/access.rst
+++ b/rtd/docs/source/core/access.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _11-access:
+.. _12-access:
 
-11 access
+12 access
 =========
 
 **Definition**: a metadata schema block containing RAiD access information
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _11.1-access.type:
+.. _12.1-access.type:
 
-11.1 access.type
+12.1 access.type
 ----------------
 
 **Definition**: a metadata schema block containing RAiD access type information
@@ -27,9 +27,9 @@
 
 **Example JSON**
 
-.. _11.2-access.typeId:
+.. _12.2-access.typeId:
 
-11.1.1 access.type.id
+12.1.1 access.type.id
 ^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the type of access granted to a RAiD metadata record
@@ -47,9 +47,9 @@
 
 **Constraints**: 'Restricted access' and 'Metadata only', though part of the upstream vocabulary, are disallowed
 
-.. _11.1.2-access.typeId.schemaUri:
+.. _12.1.2-access.typeId.schemaUri:
 
-11.1.2 access.type.schemaUri
+12.1.2 access.type.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the access type schema
@@ -64,9 +64,9 @@
 
 **Note**: The RAiD controlled list includes only a subset of the COAR vocabulary (https://vocabularies.coar-repositories.org/access_rights/1.1/), including 'Open access' and 'Embargoed access', but excluding 'Restricted access' (since no permanently restricted RAiDs are allowed), and ‘Metadata only’ (since RAiDs by design contain only metadata).
 
-.. _11.2-access.embargoExpiry:
+.. _12.2-access.embargoExpiry:
 
-11.2 access.embargoExpiry
+12.2 access.embargoExpiry
 -------------------------
 
 **Definition**: the date any embargo on access to the RAiD metadata ends
@@ -83,9 +83,9 @@
 
 **Example**: ``2021-08-28``
 
-.. _11.3-access.statement:
+.. _12.3-access.statement:
 
-11.3 access.statement
+12.3 access.statement
 ---------------------
 
 **Definition**: a metadata schema block containing an explanation of why the RAiD metadata record is not openly accessible, along with the explanation's associated properties
@@ -96,9 +96,9 @@
 
 **Example JSON**
 
-.. _11.3.1-access.statement.text:
+.. _12.3.1-access.statement.text:
 
-11.3.1 access.statement.text
+12.3.1 access.statement.text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the text of an access statement that explains any restrictions on access
@@ -113,9 +113,9 @@
 
 **Example JSON**
 
-.. _11.3.2-access.statement.language:
+.. _12.3.2-access.statement.language:
 
-11.3.2 access.statement.language
+12.3.2 access.statement.language
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: a metadata schema block declaring the language of the text in the access statement
@@ -126,9 +126,9 @@
 
 **Example JSON**
 
-.. _11.3.2.1-access.statement.language.id:
+.. _12.3.2.1-access.statement.language.id:
 
-11.3.2.1 access.statement.language.id
+12.3.2.1 access.statement.language.id
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Definition**: the language used for the access statement text, identified by a code or other identifier
@@ -141,9 +141,9 @@
 
 **Example**: ``eng``
 
-.. _11.3.2.2-access.statement.language.schemaUri:
+.. _12.3.2.2-access.statement.language.schemaUri:
 
-11.3.2.2 access.statement.language.schemaUri
+12.3.2.2 access.statement.language.schemaUri
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Definition**: the URI of the language identifier schema

--- a/rtd/docs/source/core/alternateIdentifiers.rst
+++ b/rtd/docs/source/core/alternateIdentifiers.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _8-alternateIdentifier:
+.. _9-alternateIdentifier:
 
-8 alternateIdentifier
+9 alternateIdentifier
 =====================
 
 **Definition**: a metadata schema block containing alternative local or global identifiers for the project or activity associated with the RAiD
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _8.1-alternateIdentifier.id:
+.. _9.1-alternateIdentifier.id:
 
-8.1 alternateIdentifier.id
+9.1 alternateIdentifier.id
 --------------------------
 
 **Definition**: an identifier other than the RAiD applied to the project or activity
@@ -34,9 +34,9 @@
 **Example JSON**
 
 
-.. _8.2-alternateIdentifier.type:
+.. _9.2-alternateIdentifier.type:
 
-8.2 alternateIdentifier.type
+9.2 alternateIdentifier.type
 ----------------------------
 
 **Definition**: free text description of the type of alternateIdentifier supplied

--- a/rtd/docs/source/core/alternateUrls.rst
+++ b/rtd/docs/source/core/alternateUrls.rst
@@ -1,10 +1,10 @@
 .. autosummary::
    :toctree: generated
 
-.. _9-alternateUrl:
+.. _10-alternateUrl:
 
-9 alternateUrl
-==============
+10 alternateUrl
+===============
 
 **Definition**: a metadata schema block containing alternative URLs for the project
 
@@ -14,10 +14,10 @@
 
 **Example JSON**
 
-.. _9.1-alternateUrl.url:
+.. _10.1-alternateUrl.url:
 
-9.1 alternateUrl.url
---------------------
+10.1 alternateUrl.url
+---------------------
 
 **Definition**: a link to another website related to the project or activity
 

--- a/rtd/docs/source/core/contributors.rst
+++ b/rtd/docs/source/core/contributors.rst
@@ -41,14 +41,11 @@
 **Allowed values**: *closed controlled list defined at https://vocabulary.raid.org/contributor.schemaUri/215*
 
 * ``https://orcid.org/`` (ORCID)
-
-**Proposed values**: *not yet implemented*
-
 * ``https://isni.org/`` (ISNI)
 
-**Constraints**: a PID is required and (currently) only ORCID is allowed
+**Constraints**: a PID is required; ORCID and ISNI are currently allowed
 
-**Note**: The controlled list of allowed identifier schemas is defined at https://vocabulary.raid.org/contributor.schemaUri/215 and is shared across all Registration Agencies.
+**Note**: The controlled list of allowed identifier schemas is defined at https://vocabulary.raid.org/contributor.schemaUri/215 and is shared across all Registration Agencies. An ORCID Sandbox schema (``https://sandbox.orcid.org/``) is also present in the controlled list for testing purposes only and is not intended for production RAiD records. ISNI existence is verified against the ISNI registry; local checksum validation of the ISNI check digit ahead of that lookup is planned but not yet implemented.
 
 .. _5.3-contributor.position:
 

--- a/rtd/docs/source/core/contributors.rst
+++ b/rtd/docs/source/core/contributors.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _5-contributor:
+.. _6-contributor:
 
-5 contributor
+6 contributor
 =============
 
 **Definition**: a metadata schema block containing a contributor to a RAiD and their associated properties
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _5.1-contributor.id:
+.. _6.1-contributor.id:
 
-5.1 contributor.id
+6.1 contributor.id
 ------------------
 
 **Definition**: the contributor (person) associated with a project or activity identified by a persistent identifier (PID)
@@ -27,9 +27,9 @@
 
 **Allowed values**: identifier defined by contributor.schemaUri 
 
-.. _5.2-contributor.id.schemaUri:
+.. _6.2-contributor.id.schemaUri:
 
-5.2 contributor.schemaUri
+6.2 contributor.schemaUri
 -------------------------
 
 **Definition**: the URI of the contributor identifier schema
@@ -47,9 +47,9 @@
 
 **Note**: The controlled list of allowed identifier schemas is defined at https://vocabulary.raid.org/contributor.schemaUri/215 and is shared across all Registration Agencies. An ORCID Sandbox schema (``https://sandbox.orcid.org/``) is also present in the controlled list for testing purposes only and is not intended for production RAiD records. ISNI existence is verified against the ISNI registry; local checksum validation of the ISNI check digit ahead of that lookup is planned but not yet implemented.
 
-.. _5.3-contributor.position:
+.. _6.3-contributor.position:
 
-5.3 contributor.position
+6.3 contributor.position
 ------------------------
 
 **Definition**: a metadata schema sub-block describing a contributor's administrative position on a project or activity
@@ -62,9 +62,9 @@
 
 **Note**: This property represents a contributor's administrative position on a project (such as their position on a grant application); use contributor.role to define for scientific or scholarly contribution.
 
-.. _5.3.1-contributor.position.id:
+.. _6.3.1-contributor.position.id:
 
-5.3.1 contributor.position.id
+6.3.1 contributor.position.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: a contributor's administrative position in the project
@@ -83,9 +83,9 @@
 
 **Default**: contributor.position.id for first-entered contributor (only) defaults to 'Principal or Chief Investigator' 
 
-.. _5.3.2-contributor.position.id.schemaUri:
+.. _6.3.2-contributor.position.id.schemaUri:
 
-5.3.2 contributor.position.schemaUri
+6.3.2 contributor.position.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the position schema used
@@ -100,9 +100,9 @@
 
 **Note**: Controlled list informed by Simon Cox's Project Ontology, OpenAIRE ‘Project’ guidelines, NIH definitions, ARC definitions, and DataCite Metadata Schema 4.4 Appendix 1 Table 5 'Description of contributorType'.
 
-.. _5.3.3-contributor.position.startDate:
+.. _6.3.3-contributor.position.startDate:
 
-5.3.3 contributor.position.startDate
+6.3.3 contributor.position.startDate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: date the contributor began position associated with the project or activity
@@ -121,9 +121,9 @@
 
 **Note**: Only year is required, month and day are optional (but recommended when available).
 
-.. _5.3.4-contributor.position.endDate:
+.. _6.3.4-contributor.position.endDate:
 
-5.3.4 contributor.position.endDate
+6.3.4 contributor.position.endDate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: date the contributor terminated position associated with the project or activity
@@ -140,9 +140,9 @@
 
 **Note**: Only year is required, month and day are optional (but recommended when available).
 
-.. _5.4-contributor.position.leader:
+.. _6.4-contributor.position.leader:
 
-5.4 contributor.leader
+6.4 contributor.leader
 ----------------------
 
 **Definition**: flag indicating that the contributor as a project leader
@@ -158,9 +158,9 @@
 
 **Note**: More than one contributor can be flagged as a leader if the project is jointly led.
 
-.. _5.5-contributor.position.contact:
+.. _6.5-contributor.position.contact:
 
-5.5 contributor.contact
+6.5 contributor.contact
 -----------------------
 
 **Definition**: flag indicating that the contributor as a project contact
@@ -176,9 +176,9 @@
 
 **Note**: More than one contributor can be flagged as a contact.
 
-.. _5.6-contributor.role:
+.. _6.6-contributor.role:
 
-5.6 contributor.role
+6.6 contributor.role
 --------------------
 
 **Definition**: metadata schema sub-block describing a contributor's scientific or scholarly role on a project using the CRediT vocabulary
@@ -189,9 +189,9 @@
 
 **Note**: Changes to roles are tracked through version history rather than explicitly declared.
 
-.. _5.6.1-contributor.role.id:
+.. _6.6.1-contributor.role.id:
 
-5.6.1 contributor.role.id
+6.6.1 contributor.role.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: a contributor's (person) role(s) on the Project
@@ -217,9 +217,9 @@
 * ``https://credit.niso.org/contributor-roles/writing-original-draft/``
 * ``https://credit.niso.org/contributor-roles/writing-review-editing/``
 
-.. _5.6.2-contributor.role.id.schemaUri:
+.. _6.6.2-contributor.role.id.schemaUri:
 
-5.6.2 contributor.role.schemaUri
+6.6.2 contributor.role.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the role schema used

--- a/rtd/docs/source/core/core.rst
+++ b/rtd/docs/source/core/core.rst
@@ -25,5 +25,6 @@ Contents
    alternateUrls
    relatedRaids
    access
+   metadata
 
 

--- a/rtd/docs/source/core/core.rst
+++ b/rtd/docs/source/core/core.rst
@@ -15,6 +15,7 @@ Contents
 .. toctree::
 
    identifier
+   metadata
    dates
    titles
    descriptions
@@ -25,6 +26,5 @@ Contents
    alternateUrls
    relatedRaids
    access
-   metadata
 
 

--- a/rtd/docs/source/core/dates.rst
+++ b/rtd/docs/source/core/dates.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _2-date:
+.. _3-date:
 
-2 date
+3 date
 ======
 
 **Definition**: a metadata schema block containing the start and end date of the RAiD
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _2.1-date.startDate:
+.. _3.1-date.startDate:
 
-2.1 date.startDate
+3.1 date.startDate
 ------------------
 
 **Definition**: the project or activity's start date
@@ -35,9 +35,9 @@
 
 **Note**: Only the year is required, month and day are optional (but recommended when available).
 
-.. _2.2-date.endDate:
+.. _3.2-date.endDate:
 
-2.2 date.endDate
+3.2 date.endDate
 ----------------
 
 **Definition**: the project or activity's end date

--- a/rtd/docs/source/core/descriptions.rst
+++ b/rtd/docs/source/core/descriptions.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _4-description:
+.. _5-description:
 
-4 description
+5 description
 ==============
 
 **Definition**: a metadata schema block containing the description of the RAiD and associated properties
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _4.1-description.text:
+.. _5.1-description.text:
 
-4.1 description.text
+5.1 description.text
 --------------------
 
 **Definition**: a project description that may include any additional information not captured by other metadata properties
@@ -31,9 +31,9 @@
 
 **Note**: Descriptions are intended to be flexible, and projects can use them liberally to capture information about the project that is not recorded elsewhere in the RAiD.
 
-.. _4.2-description.type:
+.. _5.2-description.type:
 
-4.2 description.type
+5.2 description.type
 --------------------
 
 **Definition**: a metadata schema block declaring the type of description
@@ -44,9 +44,9 @@
 
 **Example JSON**
 
-.. _4.2.1-description.type.id:
+.. _5.2.1-description.type.id:
 
-4.2.1 description.type.id
+5.2.1 description.type.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the type of description.
@@ -70,9 +70,9 @@
 
 **Constraints**: if a description is provided, one (and only one) primary description is mandatory
 
-.. _4.2.2-description.type.id.schemaUri:
+.. _5.2.2-description.type.id.schemaUri:
 
-4.2.2 description.type.schemaUri
+5.2.2 description.type.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the description type schema
@@ -87,9 +87,9 @@
 
 **Note**: Controlled list adapted from Vocabularies for Registry Schema 1.6.5 'Description Type' and DataCite Metadata Schema 4.4 Appendix 1 Table 10 'Description of descriptiontype'.
 
-.. _4.3-description.language:
+.. _5.3-description.language:
 
-4.3 description.language
+5.3 description.language
 ------------------------
 
 **Definition**: a metadata schema block declaring the language of the description text
@@ -100,9 +100,9 @@
 
 **Example JSON**
 
-.. _4.3.1-description.languageId:
+.. _5.3.1-description.languageId:
 
-4.3.1 description.language.id
+5.3.1 description.language.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the language used for the description text identified by a code or other identifier
@@ -115,9 +115,9 @@
 
 **Example**: ``eng``
 
-.. _4.3.1-description.languageId.schemaUri:
+.. _5.3.1-description.languageId.schemaUri:
 
-4.3.2 description.language.schemaUri
+5.3.2 description.language.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the language identifier schema

--- a/rtd/docs/source/core/identifier.rst
+++ b/rtd/docs/source/core/identifier.rst
@@ -177,9 +177,24 @@
 
 **Note**: A RAiD minted by a Registration Agency must have an SP associated with an Owner affiliated with that Agency; Registration Agencies must maintain and register lists of their Service Points with the RAiD Registration Authority. 
 
-.. _1.5-identifier.license:
+.. _1.5-identifier.raidAgencyUrl:
 
-1.5 identifier.license
+1.5 identifier.raidAgencyUrl
+-----------------------------
+
+**Definition**: the URL for the RAiD via the minting Registration Agency's own system
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Allowed values**: system-supplied URL
+
+**Note**: Set automatically by the RAiD Service software; not user-editable.
+
+.. _1.6-identifier.license:
+
+1.6 identifier.license
 ----------------------
 
 **Definition**: the licence, or licence waiver, under which the RAiD metadata record associated with this Identifier has been issued.
@@ -196,9 +211,9 @@
 
 **Note**: All RAiD metadata is available on a 'no rights reserved' basis unless prohibited by law. 
 
-.. _1.6-identifier.version:
+.. _1.7-identifier.version:
 
-1.6 identifier.version
+1.7 identifier.version
 ----------------------
 
 **Definition**: the version number of the RAiD

--- a/rtd/docs/source/core/metadata.rst
+++ b/rtd/docs/source/core/metadata.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _15-metadata:
+.. _2-metadata:
 
-15 metadata
+2 metadata
 ===========
 
 **Definition**: a metadata schema block containing system-managed record-keeping properties for the RAiD
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _15.1-metadata.created:
+.. _2.1-metadata.created:
 
-15.1 metadata.created
+2.1 metadata.created
 ----------------------
 
 **Definition**: the date and time the RAiD was created
@@ -31,9 +31,9 @@
 
 **Note**: Set automatically by the RAiD Service software when a RAiD is created; not user-editable.
 
-.. _15.2-metadata.updated:
+.. _2.2-metadata.updated:
 
-15.2 metadata.updated
+2.2 metadata.updated
 ----------------------
 
 **Definition**: the date and time the RAiD was last updated

--- a/rtd/docs/source/core/metadata.rst
+++ b/rtd/docs/source/core/metadata.rst
@@ -1,0 +1,49 @@
+.. autosummary::
+   :toctree: generated
+
+.. _15-metadata:
+
+15 metadata
+===========
+
+**Definition**: a metadata schema block containing system-managed record-keeping properties for the RAiD
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Example JSON**
+
+.. _15.1-metadata.created:
+
+15.1 metadata.created
+----------------------
+
+**Definition**: the date and time the RAiD was created
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Allowed values**: system-supplied, read-only
+
+**Format**: epoch seconds
+
+**Note**: Set automatically by the RAiD Service software when a RAiD is created; not user-editable.
+
+.. _15.2-metadata.updated:
+
+15.2 metadata.updated
+----------------------
+
+**Definition**: the date and time the RAiD was last updated
+
+**Requirement**: mandatory
+
+**Occurrence**: 1
+
+**Allowed values**: system-supplied, read-only
+
+**Format**: epoch seconds
+
+**Note**: Set automatically by the RAiD Service software whenever a RAiD is updated; not user-editable.

--- a/rtd/docs/source/core/organisations.rst
+++ b/rtd/docs/source/core/organisations.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _6-organisation:
+.. _7-organisation:
 
-6 organisation
+7 organisation
 ==============
 
 **Definition**: a metadata schema block containing the organisation associated with a RAiD and its associated properties
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _6.1-organisation.id:
+.. _7.1-organisation.id:
 
-6.1 organisation.id
+7.1 organisation.id
 -------------------
 
 **Definition**: an organisation associated with a project or activity
@@ -32,9 +32,9 @@
 * ``https://ror.org/01sf06y89`` (Macquarie University)
 * ``https://ror.org/027bh9e2`` (Leiden University)
 
-.. _6.2-organisation.schemaUri:
+.. _7.2-organisation.schemaUri:
 
-6.2 organisation.schemaUri
+7.2 organisation.schemaUri
 --------------------------
 
 **Definition**: the URI of the organisation identifier schema
@@ -47,9 +47,9 @@
 
 * ``https://ror.org/``
 
-.. _6.3-organisation.role:
+.. _7.3-organisation.role:
 
-6.3 organisation.role
+7.3 organisation.role
 ---------------------
 
 **Definition**: a metadata schema sub-block describing an organisation's role on a project
@@ -60,9 +60,9 @@
 
 **Note**: An organisation's role may change over time, but each organisation may have one and only one role at any given time.
 
-.. _6.3.1-organisation.role.id:
+.. _7.3.1-organisation.role.id:
 
-6.3.1 organisation.role.id
+7.3.1 organisation.role.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the organisation's role
@@ -87,9 +87,9 @@
 
 **Note**: Roles are likely to vary by region; controlled list adapted from Simon Cox's Project Ontology, OpenAIRE ‘Project’ guidelines, NIH definitions, ARC definitions, and DataCite Metadata Schema 4.4 Appendix 1 Table 5 'Description of contributorType'.
 
-.. _6.3.2-organisation.role.schemaUri:
+.. _7.3.2-organisation.role.schemaUri:
 
-6.3.2 organisation.role.schemaUri
+7.3.2 organisation.role.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the role schema used
@@ -102,9 +102,9 @@
 
 * ``https://vocabulary.raid.org/organisation.role.schema/359``
 
-.. _6.3.3-organisation.role.startDate:
+.. _7.3.3-organisation.role.startDate:
 
-6.3.3 organisation.role.startDate
+7.3.3 organisation.role.startDate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the date that the organisation began a role associated with the project or activity
@@ -121,9 +121,9 @@
 
 **Note**: Only the year is required; month and day are optional (but recommended when available).
 
-.. _6.3.4-organisation.role.endDate:
+.. _7.3.4-organisation.role.endDate:
 
-6.3.4 organisation.role.endDate
+7.3.4 organisation.role.endDate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the date that the organisation terminated a role associated with the project or activity

--- a/rtd/docs/source/core/relatedObjects.rst
+++ b/rtd/docs/source/core/relatedObjects.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _7-relatedObject:
+.. _8-relatedObject:
 
-7 relatedObject
+8 relatedObject
 ===============
 
 **Definition**: a metadata schema block containing inputs, outputs, and process documents related to a RAiD plus associated properties
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _7.1-relatedObject.id:
+.. _8.1-relatedObject.id:
 
-7.1 relatedObject.id
+8.1 relatedObject.id
 --------------------
 
 **Definition**: any (a) input or resource used by a project or activity, (b) output or product created by a project or activity, and/or (c) internal process documentation used within a project or activity, that is identified by a persistent identifier (PID).
@@ -27,9 +27,9 @@
 
 **Allowed values**: an identifier as specified by relatedObject.schemaUri
 
-.. _7.2-relatedObject.id.schemaUri:
+.. _8.2-relatedObject.id.schemaUri:
 
-7.2 relatedObject.schemaUri
+8.2 relatedObject.schemaUri
 ---------------------------
 
 **Definition**: the URI of the relatedObject identifier schema
@@ -52,9 +52,9 @@
 
 **Note**: Controlled list is a subset of DataCite Metadata Schema 4.4 Appendix 1 Table 8 'Description of relatedIdentiferType'.
 
-.. _7.3-relatedObject.type:
+.. _8.3-relatedObject.type:
 
-7.3 relatedObject.type
+8.3 relatedObject.type
 ----------------------
 
 **Definition**: a metadata schema sub-block describing a relatedObject's type
@@ -63,9 +63,9 @@
 
 **Occurrence**: 1
 
-.. _7.3.1-relatedObject.type.id:
+.. _8.3.1-relatedObject.type.id:
 
-7.3.1 relatedObject.type.id
+8.3.1 relatedObject.type.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: a type of input, output, or process document
@@ -107,9 +107,9 @@
 
 **Note**: Controlled list is a subset of DataCite Metadata Schema 4.4 Appendix 1 Table 7  'Description of resourceTypeGeneral', with 'Instrument', 'Funding', 'Learning Object', ‘Conference Poster’, and 'Prize' added (DataCite Metadata Schema 4.5 also adds ‘Instrument’). COAR Resource Types 3.1 (https://vocabularies.coar-repositories.org/resource_types/) used as source for missing terms where possible. 
 
-.. _7.3.2-relatedObject.type.schemaUri:
+.. _8.3.2-relatedObject.type.schemaUri:
 
-7.3.2 relatedObject.type.schemaUri
+8.3.2 relatedObject.type.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the type schema used
@@ -122,9 +122,9 @@
 
 * ``https://vocabulary.raid.org/relatedObject.type.schema/329``
 
-.. _7.4-relatedObject.category:
+.. _8.4-relatedObject.category:
 
-7.4 relatedObject.category
+8.4 relatedObject.category
 --------------------------
 
 **Definition**:  a metadata schema sub-block declaring that a relatedObject is an input, output and/or process document
@@ -135,9 +135,9 @@
 
 **Note**: A relatedObject may have more than one category (e.g.) a DMP could initially be a process document, yet eventually be published as an output.
 
-.. _7.4.1-relatedObject.category.id:
+.. _8.4.1-relatedObject.category.id:
 
-7.4.1 relatedObject.category.id
+8.4.1 relatedObject.category.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: a declaration of an object as an input, output, or other
@@ -152,9 +152,9 @@
 * ``https://vocabulary.raid.org/relatedObject.category.id/192`` (Internal process document or artefact)
 * ``https://vocabulary.raid.org/relatedObject.category.id/190`` (Output)
 
-.. _7.4.2-relatedObject.type.id.schemaUri:
+.. _8.4.2-relatedObject.type.id.schemaUri:
 
-7.4.2 relatedObject.category.schemaUri
+8.4.2 relatedObject.category.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the category schema used.

--- a/rtd/docs/source/core/relatedRaids.rst
+++ b/rtd/docs/source/core/relatedRaids.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _10-relatedRaid:
+.. _11-relatedRaid:
 
-10 relatedRaid
+11 relatedRaid
 ==============
 
 **Definition**: a metadata schema block containing related RAiDs and qualifying the relationship
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _10.1-relatedRaid.id:
+.. _11.1-relatedRaid.id:
 
-10.1 relatedRaid.id
+11.1 relatedRaid.id
 -------------------
 
 **Definition**: a subsidiary or otherwise related RAiD
@@ -27,9 +27,9 @@
 
 **Allowed values**: RAiD name
 
-.. _10.2-relatedRaid.id.type:
+.. _11.2-relatedRaid.id.type:
 
-10.2 relatedRaid.type
+11.2 relatedRaid.type
 ----------------------
 
 **Definition**: a metadata schema sub-block qualifying the relationship with a related Raid
@@ -38,9 +38,9 @@
 
 **Occurrence**: 1
 
-.. _10.2.1-relatedRaid.type.id:
+.. _11.2.1-relatedRaid.type.id:
 
-10.2.1 relatedRaid.type.id
+11.2.1 relatedRaid.type.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: a description of the relationship between the activity being registered and the related resource
@@ -62,9 +62,9 @@
 
 **Note**: Controlled list is a subset of DataCite Schema v4.4 Table 8 'Description of relatedIdentifierType'. All list items appear in the DataCite Schema. 
 
-.. _10.2.2-relatedRaid.type.schemaUri:
+.. _11.2.2-relatedRaid.type.schemaUri:
 
-10.2.2 relatedRaid.type.schemaUri
+11.2.2 relatedRaid.type.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: The URI of the relationship schema used

--- a/rtd/docs/source/core/titles.rst
+++ b/rtd/docs/source/core/titles.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _3-title:
+.. _4-title:
 
-3 title
+4 title
 =======
 
 **Definition**: a metadata schema block containing the title of the RAiD and associated properties
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _3.1-title.text:
+.. _4.1-title.text:
 
-3.1 title.text
+4.1 title.text
 --------------
 
 **Definition**: a name or title by which the project or activity is known
@@ -31,7 +31,7 @@
 
 .. 3.2-title.type:
 
-3.2 title.type
+4.2 title.type
 --------------
 
 **Definition**: a metadata schema block containing information about the title type
@@ -42,9 +42,9 @@
 
 **Example JSON**
 
-.. _3.2.1-title.type.id:
+.. _4.2.1-title.type.id:
 
-3.2.1 title.type.id
+4.2.1 title.type.id
 ^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the type of title
@@ -64,9 +64,9 @@
 
 **Note**: One (and only one) current (as per start-end dates) Primary Title is mandatory for each Title specified; additional titles are optional; any previous titles are managed by start-end dates (title type does not change).
 
-.. _3.2.2-title.type.schemaUri:
+.. _4.2.2-title.type.schemaUri:
 
-3.2.2 title.type.schemaUri
+4.2.2 title.type.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the title type schema
@@ -81,9 +81,9 @@
 
 **Note**: Controlled list adapted from Vocabularies for Registry Schema 1.6.5 'Name Type'.
 
-.. _3.3-title.language:
+.. _4.3-title.language:
 
-3.3 title.language
+4.3 title.language
 ------------------
 
 **Definition**: a metadata schema block declaring the language of the title text
@@ -94,9 +94,9 @@
 
 **Example JSON**
 
-.. _3.3.1-title.languageId:
+.. _4.3.1-title.languageId:
 
-3.3.1 title.language.id
+4.3.1 title.language.id
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the language used for the title text, identified by a code or another identifier
@@ -109,9 +109,9 @@
 
 **Example**: ``eng``
 
-.. _3.3.2-title.languageId.schemaUri:
+.. _4.3.2-title.languageId.schemaUri:
 
-3.3.2 title.language.schemaUri
+4.3.2 title.language.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the language identifier schema
@@ -126,9 +126,9 @@
 
 **Constraints**: currently limited to ISO 639:2023 (Set 3)
 
-.. _3.4-title.startDate:
+.. _4.4-title.startDate:
 
-3.4 title.startDate
+4.4 title.startDate
 -------------------
 
 **Definition**: the date the project or activity's title began being used
@@ -147,9 +147,9 @@
 
 **Note**: Only the year is required, month and day are optional (but recommended when available).
 
-.. _3.5-title.endDate:
+.. _4.5-title.endDate:
 
-3.5 title.endDate
+4.5 title.endDate
 -----------------
 
 **Definition**: the date the project or activity title was changed or stopped being used

--- a/rtd/docs/source/extended/spatialCoverages.rst
+++ b/rtd/docs/source/extended/spatialCoverages.rst
@@ -34,7 +34,6 @@
 * ``https://nominatim.openstreetmap.org/ui/details.html?osmtype=W&osmid=26707240&class=historic`` (Pompeii, Italy, OpenStreetMap)
 * ``https://www.geonames.org/264371/athens.html`` (Athens, Greece, from Geonames)
 * ``https://www.geonames.org/2161776/katoomba.html`` (Katoomba, NSW, Australia, from Geonames)
-* ``https://marineregions.org/gazetteer.php?p=details&id=62967`` (Abrolhos Australian Marine Park, Australia)
 
 .. _13.2-spatialCoverage.schemaUri:
 
@@ -49,14 +48,10 @@
 
 **Allowed values**: *open controlled list of URIs defined at https://vocabulary.raid.org/spatialCoverage.schemaUri/167*
 
-* ``https://nominatim.openstreetmap.org/`` (OpenStreetMap)
-
-**Proposed values**: *not yet implemented*
-
+* ``https://www.openstreetmap.org/`` (OpenStreetMap)
 * ``https://www.geonames.org/`` (Geonames)
-* ``https://marineregions.org/gazetteer.php`` (Marine Regions)
 
-**Note**: OpenStreetMap or (as appropriate) Marine Regions preferred, Geonames allowed; other geoname servers can be nominated by Registration Agencies.
+**Note**: OpenStreetMap preferred, Geonames allowed; other geoname servers can be nominated by Registration Agencies.
 
 .. _13.3-spatialCoverage.place:
 

--- a/rtd/docs/source/extended/spatialCoverages.rst
+++ b/rtd/docs/source/extended/spatialCoverages.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _13-spatialCoverage:
+.. _14-spatialCoverage:
 
-13 spatialCoverage
+14 spatialCoverage
 ==================
 
 **Definition**: metadata schema block containing information about any spatial region(s) or named place(s) targeted by the project
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _13.1-spatialCoverage.id:
+.. _14.1-spatialCoverage.id:
 
-13.1 spatialCoverage.id
+14.1 spatialCoverage.id
 -----------------------
 
 **Definition**: spatial region or named place that is the subject or target of the project or activity. Repeat this property as necessary to indicate different locations. Do not duplicate organisational locations
@@ -29,15 +29,14 @@
 
 **Examples**
 
-* ``https://nominatim.openstreetmap.org/ui/details.html?osmtype=R&osmid=1947835&class=boundary`` (Tundzha, Bulgaria, from OpenStreetMap)
-* ``https://nominatim.openstreetmap.org/ui/details.html?osmtype=R&osmid=186382&class=boundary`` (Bulgaria, from OpenStreetMap)
-* ``https://nominatim.openstreetmap.org/ui/details.html?osmtype=W&osmid=26707240&class=historic`` (Pompeii, Italy, OpenStreetMap)
+* ``https://www.openstreetmap.org/relation/80500`` (Australia, from OpenStreetMap)
+* ``https://www.openstreetmap.org/way/173530296`` (University of New South Wales, Kensington, Sydney, from OpenStreetMap)
 * ``https://www.geonames.org/264371/athens.html`` (Athens, Greece, from Geonames)
 * ``https://www.geonames.org/2161776/katoomba.html`` (Katoomba, NSW, Australia, from Geonames)
 
-.. _13.2-spatialCoverage.schemaUri:
+.. _14.2-spatialCoverage.schemaUri:
 
-13.2 spatialCoverage.schemaUri
+14.2 spatialCoverage.schemaUri
 ------------------------------
 
 **Definition**: the URI of the geolocation schema used for spatialCoverage
@@ -53,9 +52,9 @@
 
 **Note**: OpenStreetMap preferred, Geonames allowed; other geoname servers can be nominated by Registration Agencies.
 
-.. _13.3-spatialCoverage.place:
+.. _14.3-spatialCoverage.place:
 
-13.3 spatialCoverage.place
+14.3 spatialCoverage.place
 --------------------------
 
 **Definition**: metadata schema sub-block containing free-text place names or descriptions plus associated metadata properties
@@ -64,9 +63,9 @@
 
 **Occurrence**: 0-n
 
-.. _13.3.1-spatialCoverage.place.text:
+.. _14.3.1-spatialCoverage.place.text:
 
-13.3.1 spatialCoverage.place.text
+14.3.1 spatialCoverage.place.text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: free text description of one or more geographic locations that are the subject or target of the project or activity; use to specify or describe a geographic location in a manner not covered by spatialCoverage.id
@@ -79,9 +78,9 @@
 
 **Constraints**: do not duplicate information from spatialCoverage.id above; do not use for organisational locations (which are derived from the organisation's ROR)
 
-.. _13.3.2-spatialCoverage.place.language:
+.. _14.3.2-spatialCoverage.place.language:
 
-13.3.2 spatialCoverage.place.language
+14.3.2 spatialCoverage.place.language
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: metadata schema block declaring the language of spatialCoverage.place.text
@@ -92,9 +91,9 @@
 
 **Example JSON**
 
-.. _13.3.2.1-spatialCoverage.place.language.id:
+.. _14.3.2.1-spatialCoverage.place.language.id:
 
-13.3.2.1 spatialCoverage.place.language.id
+14.3.2.1 spatialCoverage.place.language.id
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Definition**: language used for spatialCoverage.place.text identified by a code or other identifier
@@ -107,9 +106,9 @@
 
 **Example**: ``eng``
 
-.. _13.3.2.2-spatialCoverage.place.language.schemaUri:
+.. _14.3.2.2-spatialCoverage.place.language.schemaUri:
 
-13.3.2.2 spatialCoverage.place.language.schemaUri
+14.3.2.2 spatialCoverage.place.language.schemaUri
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Definition**: the URI of the language identifier schema

--- a/rtd/docs/source/extended/subjects.rst
+++ b/rtd/docs/source/extended/subjects.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _12-subject:
+.. _13-subject:
 
-12 subject
+13 subject
 ==========
 
 **Definition**: metadata schema block containing the subject area of the RAiD plus associated properties
@@ -14,9 +14,9 @@
 
 **Example JSON**
 
-.. _12.1-subject.id:
+.. _13.1-subject.id:
 
-12.1 subject.id
+13.1 subject.id
 ---------------
 
 **Definition**: identifier (URI) for a subject area or classification code describing the project or activity
@@ -29,12 +29,11 @@
 
 **Examples**
 
-* https://vocabs.ardc.edu.au/repository/api/lda/anzsrc-2020-for/resource?uri=https://linked.data.gov.au/def/anzsrc-for/2020/430106 (ANZSRC 2020 Fields of Research code: ‘Digital Archaeology’)
-* https://id.loc.gov/authorities/subject/sh85118622.html (LoC 'Science and State')
+* https://linked.data.gov.au/def/anzsrc-for/2020/430106 (ANZSRC 2020 Fields of Research code: ‘Digital Archaeology’)
 
-.. _12.2-subject.schemaUri:
+.. _13.2-subject.schemaUri:
 
-12.2 subject.schemaUri
+13.2 subject.schemaUri
 ----------------------
 
 **Definition**: the URI of the subject identifier schema
@@ -50,9 +49,9 @@
 
 Other subject schemas can be nominated by Registration Agencies.
 
-.. _12.3-subject.keyword:
+.. _13.3-subject.keyword:
 
-12.3 subject.keyword
+13.3 subject.keyword
 --------------------
 
 **Definition**: metadata schema sub-block containing free-text keyword describing a project plus associated properties
@@ -61,9 +60,9 @@ Other subject schemas can be nominated by Registration Agencies.
 
 **Occurrence**: 0-n
 
-.. _12.3.1-subject.keyword.text:
+.. _13.3.1-subject.keyword.text:
 
-12.3.1 subject.keyword.text
+13.3.1 subject.keyword.text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: unconstrained keyword or key phrase describing the project or activity
@@ -76,9 +75,9 @@ Other subject schemas can be nominated by Registration Agencies.
 
 **Constraints**: do not duplicate Subject(s) above
 
-.. _12.3.2-subject.keyword.language:
+.. _13.3.2-subject.keyword.language:
 
-12.3.2 subject.keyword.language
+13.3.2 subject.keyword.language
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: metadata schema block declaring the language of the subject keyword text
@@ -89,9 +88,9 @@ Other subject schemas can be nominated by Registration Agencies.
 
 **Example JSON**
 
-.. _12.3.2.1-subject.keyword.language.id:
+.. _13.3.2.1-subject.keyword.language.id:
 
-12.3.2.1 subject.keyword.language.id
+13.3.2.1 subject.keyword.language.id
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Definition**: language used for the subject keyword text identified by a code or other identifier
@@ -104,9 +103,9 @@ Other subject schemas can be nominated by Registration Agencies.
 
 **Example**: ``eng``
 
-.. _12.3.2.2-subject.keyword.language.schemaUri:
+.. _13.3.2.2-subject.keyword.language.schemaUri:
 
-12.3.2.2 subject.keyword.language.schemaUri
+13.3.2.2 subject.keyword.language.schemaUri
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Definition**: the URI of the language identifier schema

--- a/rtd/docs/source/extended/subjects.rst
+++ b/rtd/docs/source/extended/subjects.rst
@@ -46,10 +46,7 @@
 **Allowed values**: *open controlled list of URIs defined at https://vocabulary.raid.org/subject.schemaUri/193*
 
 * https://vocabs.ardc.edu.au/viewById/316 (Australian and New Zealand Standard Research Classification 2020: Fields of Research)
-
-**Proposed values**: *not yet implemented*
-
-* https://id.loc.gov/authorities/subject.html (Library of Congress Subject Headings)
+* https://vocabs.ardc.edu.au/viewById/317 (Australian and New Zealand Standard Research Classification 2020: Socio-Economic Objectives)
 
 Other subject schemas can be nominated by Registration Agencies.
 

--- a/rtd/docs/source/extended/traditionalKnowledge.rst
+++ b/rtd/docs/source/extended/traditionalKnowledge.rst
@@ -1,9 +1,9 @@
 .. autosummary::
    :toctree: generated
 
-.. _14-traditionalKnowledge:
+.. _15-traditionalKnowledge:
 
-14 traditionalKnowledge
+15 traditionalKnowledge
 =======================
 
 **Note**: This metadata block is not yet implemented in the RAiD service.
@@ -16,9 +16,9 @@
 
 **Example JSON**
 
-.. _14.1-traditionalKnowledge.id:
+.. _15.1-traditionalKnowledge.id:
 
-14.1 traditionalKnowledge.id
+15.1 traditionalKnowledge.id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: identifier (URI) linking to a verified source for TK or BC Labels or Notices pertaining to a project or activity
@@ -35,9 +35,9 @@
 
 **Note**: Currently only Local Contexts Hub Projects are allowed as a source for validated TK/BC Labels and Notices.
 
-.. _14.2-traditionalKnowledgeLabel.schemaUri:
+.. _15.2-traditionalKnowledgeLabel.schemaUri:
 
-14.2 traditionalKnowledge.schemaUri
+15.2 traditionalKnowledge.schemaUri
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Definition**: the URI of the TK/BC label identifier schema

--- a/rtd/docs/source/index.rst
+++ b/rtd/docs/source/index.rst
@@ -96,6 +96,7 @@ Contents
       core/alternateUrls
       core/relatedRaids
       core/access
+      core/metadata
    extended/extended
       extended/subjects
       extended/traditionalKnowledgeLabels

--- a/rtd/docs/source/index.rst
+++ b/rtd/docs/source/index.rst
@@ -86,6 +86,7 @@ Contents
 
    core/core
       core/identifier
+      core/metadata
       core/dates
       core/titles
       core/descriptions
@@ -96,7 +97,6 @@ Contents
       core/alternateUrls
       core/relatedRaids
       core/access
-      core/metadata
    extended/extended
       extended/subjects
       extended/traditionalKnowledgeLabels


### PR DESCRIPTION
## Summary

Re-opened after the first attempt (#29) was accidentally merged into the previous `docs-preview` branch. That branch has been deleted and recreated fresh off `main`; this PR targets the new one. Nothing has been merged into `main`.

Audited `rtd/docs/source/` and `doc/metadata-block-field-naming.md` against the RAiD LinkML model, the actual running service (`au-research/raid-au`), and a production data export, since both had drifted from reality over time.

- `contributors.rst`: ISNI is live (was marked "proposed, not yet implemented"); noted ORCID Sandbox and the still-pending local checksum hardening (RAID-791)
- `spatialCoverages.rst`: Geonames is live; corrected the OpenStreetMap schemaUri and examples to what's actually configured/live; removed Marine Regions (descoped)
- `subjects.rst`: added ANZSRC Socio-Economic Objectives (real seed data since Dec 2025); removed Library of Congress (descoped), including a leftover example; corrected the ANZSRC FoR example to the real production `id` format
- `identifier.rst`: documented `raidAgencyUrl`, confirmed mandatory/system-supplied (present in 100% of a 575-record production sample)
- `metadata.rst` (new page, section 2, right after `identifier`): documents the previously-undocumented `metadata` block — `created`/`updated` only; `raidModelVersion` intentionally left out since nothing implements it yet. Renumbered every subsequent core/extended section accordingly.
- `metadata-block-field-naming.md`: rewritten to describe the nested dot-path field convention that's actually implemented (e.g. `identifier.schemaUri`), replacing a flattened-field-name convention (`identifierSchemeUri`) that was never real

Every change was verified against validator source, Spring config, DB migration history, relevant Jira tickets, and the ARDC RAiD AU Zenodo data archive (`10.5281/zenodo.21331421`) — not just the schema/vocab layer, which turned out to be an unreliable signal on its own in both directions.

## Test plan

- [x] Confirm Sphinx build succeeds (`cd rtd/docs && make html`)
- [x] Spot-check rendered `identifier`, `metadata`, `contributors`, `subjects`, `spatialCoverages` pages
- [x] Confirm section numbering (2 for `metadata`, cascading through the rest) renders correctly and doesn't collide with anything else in the toctree

🤖 Generated with [Claude Code](https://claude.com/claude-code)