### PR TITLE
Fill Example JSON placeholders for every block and sub-block

### DIFF
--- a/rtd/docs/source/core/access.rst
+++ b/rtd/docs/source/core/access.rst
@@ -14,6 +14,25 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "access": {
+       "type": {
+         "id": "https://vocabularies.coar-repositories.org/access_rights/c_f1cf/",
+         "schemaUri": "https://vocabularies.coar-repositories.org/access_rights/"
+       },
+       "embargoExpiry": "2027-06-30",
+       "statement": {
+         "text": "Metadata for this record is embargoed until the primary data custodian approves release of the linked data collection.",
+         "language": {
+           "id": "eng",
+           "schemaUri": "https://www.iso.org/standard/74575.html"
+         }
+       }
+     }
+   }
+
 .. _12.1-access.type:
 
 12.1 access.type
@@ -26,6 +45,15 @@
 **Occurrence**: 1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "type": {
+       "id": "https://vocabularies.coar-repositories.org/access_rights/c_f1cf/",
+       "schemaUri": "https://vocabularies.coar-repositories.org/access_rights/"
+     }
+   }
 
 .. _12.2-access.typeId:
 
@@ -96,6 +124,18 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "statement": {
+       "text": "Metadata for this record is embargoed until the primary data custodian approves release of the linked data collection.",
+       "language": {
+         "id": "eng",
+         "schemaUri": "https://www.iso.org/standard/74575.html"
+       }
+     }
+   }
+
 .. _12.3.1-access.statement.text:
 
 12.3.1 access.statement.text
@@ -111,8 +151,6 @@
 
 **Constraints**: maximum 1,000 characters
 
-**Example JSON**
-
 .. _12.3.2-access.statement.language:
 
 12.3.2 access.statement.language
@@ -125,6 +163,15 @@
 **Occurrence**: 0-1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "language": {
+       "id": "eng",
+       "schemaUri": "https://www.iso.org/standard/74575.html"
+     }
+   }
 
 .. _12.3.2.1-access.statement.language.id:
 

--- a/rtd/docs/source/core/alternateIdentifiers.rst
+++ b/rtd/docs/source/core/alternateIdentifiers.rst
@@ -14,6 +14,17 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "alternateIdentifier": [
+       {
+         "id": "UTAS-IMAS-2024-0412",
+         "type": "Institutional research management system project ID"
+       }
+     ]
+   }
+
 .. _9.1-alternateIdentifier.id:
 
 9.1 alternateIdentifier.id
@@ -31,9 +42,6 @@
 
 **Note**: An alternateIdentifer.id may be any alphanumeric string that is unique within its domain of issue, for example a local identifier unique to an organisation. The alternateIdentifier.id represents an additional identifier for the same instance of the project or activity; its referent is identical to that of the RAiD.
 
-**Example JSON**
-
-
 .. _9.2-alternateIdentifier.type:
 
 9.2 alternateIdentifier.type
@@ -48,5 +56,3 @@
 **Allowed values**: free text
 
 **Example**: 'A local project ID in the university CRIS'
-
-**Example JSON**

--- a/rtd/docs/source/core/alternateUrls.rst
+++ b/rtd/docs/source/core/alternateUrls.rst
@@ -14,6 +14,16 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "alternateUrl": [
+       {
+         "url": "https://imas.utas.edu.au/projects/kelpwatch"
+       }
+     ]
+   }
+
 .. _10.1-alternateUrl.url:
 
 10.1 alternateUrl.url
@@ -30,5 +40,3 @@
 **Note**: An alternateURL can be used to point to any other project website, whether standalone, organisational, or in a platform such as Open Science Framework.
 
 **Example**: ``https://osf.io/puwgx/`` (an Open Science Framework project page)
-
-**Example JSON**

--- a/rtd/docs/source/core/contributors.rst
+++ b/rtd/docs/source/core/contributors.rst
@@ -14,6 +14,55 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "contributor": [
+       {
+         "id": "https://orcid.org/0000-0002-1825-0097",
+         "schemaUri": "https://orcid.org/",
+         "position": [
+           {
+             "id": "https://vocabulary.raid.org/contributor.position.schema/307",
+             "schemaUri": "https://vocabulary.raid.org/contributor.position.schema/305",
+             "startDate": "2024-03-01"
+           }
+         ],
+         "role": [
+           {
+             "id": "https://credit.niso.org/contributor-roles/conceptualization/",
+             "schemaUri": "https://credit.niso.org/"
+           },
+           {
+             "id": "https://credit.niso.org/contributor-roles/supervision/",
+             "schemaUri": "https://credit.niso.org/"
+           }
+         ],
+         "leader": true,
+         "contact": true
+       },
+       {
+         "id": "https://orcid.org/0000-0001-9971-0253",
+         "schemaUri": "https://orcid.org/",
+         "position": [
+           {
+             "id": "https://vocabulary.raid.org/contributor.position.schema/308",
+             "schemaUri": "https://vocabulary.raid.org/contributor.position.schema/305",
+             "startDate": "2024-06-01"
+           }
+         ],
+         "role": [
+           {
+             "id": "https://credit.niso.org/contributor-roles/investigation/",
+             "schemaUri": "https://credit.niso.org/"
+           }
+         ],
+         "leader": false,
+         "contact": false
+       }
+     ]
+   }
+
 .. _6.1-contributor.id:
 
 6.1 contributor.id

--- a/rtd/docs/source/core/dates.rst
+++ b/rtd/docs/source/core/dates.rst
@@ -14,6 +14,15 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "date": {
+       "startDate": "2024-03-01",
+       "endDate": "2027-02-28"
+     }
+   }
+
 .. _3.1-date.startDate:
 
 3.1 date.startDate

--- a/rtd/docs/source/core/descriptions.rst
+++ b/rtd/docs/source/core/descriptions.rst
@@ -14,6 +14,35 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "description": [
+       {
+         "text": "KELPWATCH tracks the recovery of giant kelp forests at twelve reference sites along the Great Southern Reef, combining diver surveys with fixed underwater imagery to measure canopy extent and species assemblage change following marine heatwaves.",
+         "type": {
+           "id": "https://vocabulary.raid.org/description.type.schema/318",
+           "schemaUri": "https://vocabulary.raid.org/description.type.schema/320"
+         },
+         "language": {
+           "id": "eng",
+           "schemaUri": "https://www.iso.org/standard/74575.html"
+         }
+       },
+       {
+         "text": "Quarterly diver transects paired with time-lapse imagery, analysed against sea surface temperature records.",
+         "type": {
+           "id": "https://vocabulary.raid.org/description.type.schema/8",
+           "schemaUri": "https://vocabulary.raid.org/description.type.schema/320"
+         },
+         "language": {
+           "id": "eng",
+           "schemaUri": "https://www.iso.org/standard/74575.html"
+         }
+       }
+     ]
+   }
+
 .. _5.1-description.text:
 
 5.1 description.text
@@ -43,6 +72,15 @@
 **Occurrence**: 1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "type": {
+       "id": "https://vocabulary.raid.org/description.type.schema/318",
+       "schemaUri": "https://vocabulary.raid.org/description.type.schema/320"
+     }
+   }
 
 .. _5.2.1-description.type.id:
 
@@ -99,6 +137,15 @@
 **Occurrence**: 0-1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "language": {
+       "id": "eng",
+       "schemaUri": "https://www.iso.org/standard/74575.html"
+     }
+   }
 
 .. _5.3.1-description.languageId:
 

--- a/rtd/docs/source/core/identifier.rst
+++ b/rtd/docs/source/core/identifier.rst
@@ -14,6 +14,27 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "identifier": {
+       "id": "https://raid.org/10.99999/7a2f4c81",
+       "schemaUri": "https://raid.org/",
+       "registrationAgency": {
+         "id": "https://ror.org/038sjwq14",
+         "schemaUri": "https://ror.org/"
+       },
+       "owner": {
+         "id": "https://ror.org/01nfmeh72",
+         "schemaUri": "https://ror.org/",
+         "servicePoint": 20000003
+       },
+       "raidAgencyUrl": "https://static.prod.raid.org.au/raids/10.99999/7a2f4c81",
+       "license": "Creative Commons CC-0",
+       "version": 3
+     }
+   }
+
 .. _1.1-identifier.id:
 
 1.1 identifier.id

--- a/rtd/docs/source/core/metadata.rst
+++ b/rtd/docs/source/core/metadata.rst
@@ -16,6 +16,15 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "metadata": {
+       "created": 1709607127,
+       "updated": 1751505715
+     }
+   }
+
 .. _2.1-metadata.created:
 
 2.1 metadata.created

--- a/rtd/docs/source/core/organisations.rst
+++ b/rtd/docs/source/core/organisations.rst
@@ -14,6 +14,35 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "organisation": [
+       {
+         "id": "https://ror.org/01nfmeh72",
+         "schemaUri": "https://ror.org/",
+         "role": [
+           {
+             "id": "https://vocabulary.raid.org/organisation.role.schema/182",
+             "schemaUri": "https://vocabulary.raid.org/organisation.role.schema/359",
+             "startDate": "2024-03-01"
+           }
+         ]
+       },
+       {
+         "id": "https://ror.org/03x57gn41",
+         "schemaUri": "https://ror.org/",
+         "role": [
+           {
+             "id": "https://vocabulary.raid.org/organisation.role.schema/184",
+             "schemaUri": "https://vocabulary.raid.org/organisation.role.schema/359",
+             "startDate": "2024-03-01"
+           }
+         ]
+       }
+     ]
+   }
+
 .. _7.1-organisation.id:
 
 7.1 organisation.id

--- a/rtd/docs/source/core/relatedObjects.rst
+++ b/rtd/docs/source/core/relatedObjects.rst
@@ -14,6 +14,41 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "relatedObject": [
+       {
+         "id": "https://doi.org/10.5555/aurora-suite-recording",
+         "schemaUri": "https://doi.org/",
+         "type": {
+           "id": "https://vocabulary.raid.org/relatedObject.type.schema/261",
+           "schemaUri": "https://vocabulary.raid.org/relatedObject.type.schema/329"
+         },
+         "category": [
+           {
+             "id": "https://vocabulary.raid.org/relatedObject.category.id/190",
+             "schemaUri": "https://vocabulary.raid.org/relatedObject.category.schemaUri/386"
+           }
+         ]
+       },
+       {
+         "id": "https://web.archive.org/web/20260219073130/https://www.raid.org/",
+         "schemaUri": "https://web.archive.org/",
+         "type": {
+           "id": "https://vocabulary.raid.org/relatedObject.type.schema/265",
+           "schemaUri": "https://vocabulary.raid.org/relatedObject.type.schema/329"
+         },
+         "category": [
+           {
+             "id": "https://vocabulary.raid.org/relatedObject.category.id/191",
+             "schemaUri": "https://vocabulary.raid.org/relatedObject.category.schemaUri/386"
+           }
+         ]
+       }
+     ]
+   }
+
 .. _8.1-relatedObject.id:
 
 8.1 relatedObject.id

--- a/rtd/docs/source/core/relatedRaids.rst
+++ b/rtd/docs/source/core/relatedRaids.rst
@@ -14,6 +14,20 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "relatedRaid": [
+       {
+         "id": "https://raid.org/10.99999/1f0ab934",
+         "type": {
+           "id": "https://vocabulary.raid.org/relatedRaid.type.schema/202",
+           "schemaUri": "https://vocabulary.raid.org/relatedRaid.type.schema/367"
+         }
+       }
+     ]
+   }
+
 .. _11.1-relatedRaid.id:
 
 11.1 relatedRaid.id

--- a/rtd/docs/source/core/titles.rst
+++ b/rtd/docs/source/core/titles.rst
@@ -14,6 +14,37 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "title": [
+       {
+         "text": "Kelp Forest Recovery Monitoring on the Great Southern Reef",
+         "type": {
+           "id": "https://vocabulary.raid.org/title.type.schema/5",
+           "schemaUri": "https://vocabulary.raid.org/title.type.schema/376"
+         },
+         "language": {
+           "id": "eng",
+           "schemaUri": "https://www.iso.org/standard/74575.html"
+         },
+         "startDate": "2024-03-01"
+       },
+       {
+         "text": "KELPWATCH",
+         "type": {
+           "id": "https://vocabulary.raid.org/title.type.schema/156",
+           "schemaUri": "https://vocabulary.raid.org/title.type.schema/376"
+         },
+         "language": {
+           "id": "eng",
+           "schemaUri": "https://www.iso.org/standard/74575.html"
+         },
+         "startDate": "2024-03-01"
+       }
+     ]
+   }
+
 .. _4.1-title.text:
 
 4.1 title.text
@@ -41,6 +72,15 @@
 **Occurrence**: 1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "type": {
+       "id": "https://vocabulary.raid.org/title.type.schema/5",
+       "schemaUri": "https://vocabulary.raid.org/title.type.schema/376"
+     }
+   }
 
 .. _4.2.1-title.type.id:
 
@@ -93,6 +133,15 @@
 **Occurrence**: 0-1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "language": {
+       "id": "eng",
+       "schemaUri": "https://www.iso.org/standard/74575.html"
+     }
+   }
 
 .. _4.3.1-title.languageId:
 

--- a/rtd/docs/source/extended/spatialCoverages.rst
+++ b/rtd/docs/source/extended/spatialCoverages.rst
@@ -14,6 +14,26 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "spatialCoverage": [
+       {
+         "id": "https://www.openstreetmap.org/?#map=10/-43.0526/147.2472",
+         "schemaUri": "https://www.openstreetmap.org/",
+         "place": [
+           {
+             "text": "D'Entrecasteaux Channel, Tasmania, Australia",
+             "language": {
+               "id": "eng",
+               "schemaUri": "https://www.iso.org/standard/74575.html"
+             }
+           }
+         ]
+       }
+     ]
+   }
+
 .. _14.1-spatialCoverage.id:
 
 14.1 spatialCoverage.id
@@ -90,6 +110,15 @@
 **Occurrence**: 0-1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "language": {
+       "id": "eng",
+       "schemaUri": "https://www.iso.org/standard/74575.html"
+     }
+   }
 
 .. _14.3.2.1-spatialCoverage.place.language.id:
 

--- a/rtd/docs/source/extended/subjects.rst
+++ b/rtd/docs/source/extended/subjects.rst
@@ -14,6 +14,33 @@
 
 **Example JSON**
 
+.. code-block:: json
+
+   {
+     "subject": [
+       {
+         "id": "https://linked.data.gov.au/def/anzsrc-for/2020/310305",
+         "schemaUri": "https://vocabs.ardc.edu.au/viewById/316",
+         "keyword": [
+           {
+             "text": "kelp forest",
+             "language": {
+               "id": "eng",
+               "schemaUri": "https://www.iso.org/standard/74575.html"
+             }
+           },
+           {
+             "text": "marine heatwave",
+             "language": {
+               "id": "eng",
+               "schemaUri": "https://www.iso.org/standard/74575.html"
+             }
+           }
+         ]
+       }
+     ]
+   }
+
 .. _13.1-subject.id:
 
 13.1 subject.id
@@ -87,6 +114,15 @@ Other subject schemas can be nominated by Registration Agencies.
 **Occurrence**: 0-1
 
 **Example JSON**
+
+.. code-block:: json
+
+   {
+     "language": {
+       "id": "eng",
+       "schemaUri": "https://www.iso.org/standard/74575.html"
+     }
+   }
 
 .. _13.3.2.1-subject.keyword.language.id:
 

--- a/rtd/docs/source/index.rst
+++ b/rtd/docs/source/index.rst
@@ -71,7 +71,7 @@ Furthermore, some properties include additional information.
 
 **Examples** provide models for the value.
 
-**Example JSON** provides an indicative JSON code snippet.
+**Example JSON** provides an indicative JSON snippet showing how a block or sub-block appears in a RAiD metadata record, including its enclosing property name. Properties that hold a single value are illustrated by **Example** instead. Snippets are drawn from fictional projects; organisation identifiers, vocabulary URIs and language codes are real, while RAiD names, contributor identifiers and object identifiers are illustrative only and will not resolve.
 
 **Note** contains any additional information about the property.
 


### PR DESCRIPTION
Replaces the 23 empty `**Example JSON**` markers with valid JSON snippets, and removes the 4 markers that sat on single-value properties where the existing `**Example**` already does the job (`alternateIdentifier.id`, `alternateIdentifier.type`, `alternateUrl.url`, `access.statement.text`).

Builds on the accuracy sweep in #32, so every vocabulary URI in the snippets is a corrected one.

## What the snippets show

Each snippet includes the enclosing property name, and shows repeating blocks as the arrays they actually are, so the occurrence rules are visible in the example itself rather than only in the prose above it.

Structures were modelled on real production payloads, so field nesting matches what the API returns — `date` as an object, `title` as an array, `metadata` timestamps as epoch seconds, and so on.

## Where the content comes from

Three fictional projects, chosen so each block is illustrated by something plausible:

- a marine ecology field project, used for most blocks
- a health data linkage project under embargo, used for the `access` block, which needs a non-open access type to be meaningful
- a creative arts project, used for `relatedObject`

Identifiers are real where they are structural and verifiable, and illustrative where a real value would point at a real person or a real work:

| Identifier | Treatment |
| --- | --- |
| Organisation IDs | Real RORs, confirmed against the ROR API |
| Vocabulary, COAR, ISO 639 URIs | The live values, matching #32 |
| ANZSRC Fields of Research codes | Real, confirmed against linked.data.gov.au |
| Contributor IDs | ORCID's fictional demo personas (see below) |
| RAiD names | Illustrative `10.99999` prefix, not registered in the Handle system |
| Object DOIs | The `10.5555` DOI test prefix |

On contributor identifiers specifically: Josiah Carberry (`0000-0002-1825-0097`) exists in the production ORCID registry precisely as a demo persona. Sofía María Hernández Garcia's identifier is unassigned in the production registry, so it names no real person, and the ORCID Sandbox schema is deliberately avoided since `contributor.schemaUri` warns against it for production records.

Worth noting separately: two ORCIDs currently used as examples elsewhere in the RAiD codebase belong to real people — `0000-0002-0448-8774` in `InMemoryStubTestData.java` and `0000-0002-4582-7728` in `doc/reference/schema-org-json-ld-mapping.md`. Neither appears in this documentation, but the latter is in a public document.

## Convention note

`index.rst` now describes what `**Example JSON**` covers, and states plainly which identifiers in the examples are real and which will not resolve, so nobody copies an illustrative RAiD name into a record expecting it to work.

## Verification

Sphinx builds clean with zero warnings. All 23 snippets were generated from validated structures and re-parsed as JSON after insertion; none is malformed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)